### PR TITLE
Add initial long-term tasks. When AutoAddCron is set to true, short-term tasks will be added automatically.

### DIFF
--- a/crontab.list.sample
+++ b/crontab.list.sample
@@ -29,6 +29,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/data/data/com
 0 0,8,12,16 * * * /root/shell/jd_joy_reward.sh
 0 0,6 * * * /root/shell/jd_joy_steal.sh
 28 7 * * * /root/shell/jd_kd.sh
+10-20/5 13 * * * /root/shell/jd_live.sh
 15 1 * * * /root/shell/jd_lotteryMachine.sh
 40 */4 * * * /root/shell/jd_moneyTree.sh
 20 0,20 * * * /root/shell/jd_necklace.sh


### PR DESCRIPTION
Add initial long-term tasks. When AutoAddCron is set to true, short-term tasks will be added automatically.