### PR TITLE
接口路径改为使用相对路径

### DIFF
--- a/panel/public/auth.html
+++ b/panel/public/auth.html
@@ -26,9 +26,9 @@
 			let timeStamp = (new Date()).getTime()
 			$user = $(".username").val();
 			$password = $(".password").val();
-			$.post('/auth?t='+timeStamp, { username: $user, password: $password }, function (data) {
+			$.post('./auth?t='+timeStamp, { username: $user, password: $password }, function (data) {
 				if (data.err == 0) {
-					window.location.href = "/home";
+					window.location.href = "./home";
 				} else {
 					Swal.fire({
 						text: data.msg

--- a/panel/public/crontab.html
+++ b/panel/public/crontab.html
@@ -20,11 +20,11 @@
         <div class="diffs">
             <nav>
                 <ul>
-                    <li><a href="/home">首页</a></li>
-                    <li class="active"><a href="/crontab">定时设定</a></li>
-                    <li><a href="/diff">对比工具</a></li>
-                    <li><a href="/changepwd">修改密码</a></li>
-                    <li><a href="/logout">退出</a></li>
+                    <li><a href="./home">首页</a></li>
+                    <li class="active"><a href="./crontab">定时设定</a></li>
+                    <li><a href="./diff">对比工具</a></li>
+                    <li><a href="./changepwd">修改密码</a></li>
+                    <li><a href="./logout">退出</a></li>
                 </ul>
             </nav>
             <header>
@@ -48,14 +48,14 @@
                 theme: 'dracula'
             });
             let timeStamp = (new Date()).getTime()
-            $.get("/api/config/crontab?t="+timeStamp, function (data) {
+            $.get("./api/config/crontab?t="+timeStamp, function (data) {
                 editor.setValue(data);
             });
 
             $('#save').click(function () {
                 var confContent = editor.getValue();
                 let timeStamp = (new Date()).getTime()
-                $.post('/api/save?t='+timeStamp, { content: confContent, name: "crontab.list" }, function (data) {
+                $.post('./api/save?t='+timeStamp, { content: confContent, name: "crontab.list" }, function (data) {
                     let icon = (data.err == 0) ? "success" : "error"
                     Swal.fire({
                         title:data.title,

--- a/panel/public/diff.html
+++ b/panel/public/diff.html
@@ -22,11 +22,11 @@
         <div class="diffs">
             <nav>
                 <ul>
-                    <li><a href="/home">首页</a></li>
-                    <li><a href="/crontab" >定时设定</a></li>
-                    <li class="active"><a href="/diff">对比工具</a></li>
-                    <li><a href="/changepwd" >修改密码</a></li>
-                    <li><a href="/logout" >退出</a></li>
+                    <li><a href="./home">首页</a></li>
+                    <li><a href="./crontab" >定时设定</a></li>
+                    <li class="active"><a href="./diff">对比工具</a></li>
+                    <li><a href="./changepwd" >修改密码</a></li>
+                    <li><a href="./logout" >退出</a></li>
                 </ul>
             </nav>
             <header>
@@ -45,8 +45,8 @@
         <div class="sources">
             <p>查看源文件，注意将浏览器编码切换为 UTF-8 。</p>
             <ul>
-                <li><a id="file1" href="/api/config/config">查看 config.sh</a></li>
-                <li><a id="file2" href="/api/config/sample">查看 config.sh.sample</a></li>
+                <li><a id="file1" href="./api/config/config">查看 config.sh</a></li>
+                <li><a id="file2" href="./api/config/sample">查看 config.sh.sample</a></li>
             </ul>
         </div>
         <br>
@@ -74,12 +74,12 @@
 
             editor_width: 'calc(50% - 25px)',
             editor_height: '100%',
-            
+
             lhs: function (setValue) {
-                downloadFile('/api/config/config?t='+timeStamp, setValue);
+                downloadFile('./api/config/config?t='+timeStamp, setValue);
             },
             rhs: function (setValue) {
-                downloadFile('/api/config/sample?t='+timeStamp, setValue);
+                downloadFile('./api/config/sample?t='+timeStamp, setValue);
             }
         });
 
@@ -105,7 +105,7 @@
         $('#save').click(function () {
             var confContent = comp.mergely('get', 'lhs');
             let timeStamp = (new Date()).getTime()
-            $.post('/api/save?t='+timeStamp, { content: confContent, name: "config.sh" }, function (data) {
+            $.post('./api/save?t='+timeStamp, { content: confContent, name: "config.sh" }, function (data) {
                 let icon = (data.err == 0) ? "success" : "error"
                     Swal.fire({
                         title:data.title,

--- a/panel/public/home.html
+++ b/panel/public/home.html
@@ -21,11 +21,11 @@
         <div class="diffs">
             <nav>
                 <ul>
-                    <li class="active"><a href="/home">首页</a></li>
-                    <li><a href="/crontab">定时设定</a></li>
-                    <li><a href="/diff">对比工具</a></li>
-                    <li><a href="/changepwd">修改密码</a></li>
-                    <li><a href="/logout">退出</a></li>
+                    <li class="active"><a href="./home">首页</a></li>
+                    <li><a href="./crontab">定时设定</a></li>
+                    <li><a href="./diff">对比工具</a></li>
+                    <li><a href="./changepwd">修改密码</a></li>
+                    <li><a href="./logout">退出</a></li>
                 </ul>
             </nav>
             <header>
@@ -63,7 +63,7 @@
                 theme: 'dracula'
             });
             let timeStamp = (new Date()).getTime()
-            $.get("/api/config/config?t="+timeStamp, function (data) {
+            $.get("./api/config/config?t="+timeStamp, function (data) {
                 editor.setValue(data);
             });
 
@@ -87,7 +87,7 @@
             function checkLogin() {
                 var timeId = setInterval(() => {
                     let timeStamp = (new Date()).getTime()
-                    $.get('/cookie?t='+timeStamp, function (data) {
+                    $.get('./cookie?t='+timeStamp, function (data) {
                         if (data.err == 0) {
                             clearInterval(timeId)
                             $("#qrcontainer").addClass("hidden")
@@ -114,7 +114,7 @@
 
             function get_code() {
                 let timeStamp = (new Date()).getTime()
-                $.get('/qrcode?t='+timeStamp, function (data) {
+                $.get('./qrcode?t='+timeStamp, function (data) {
                     if (data.err == 0) {
                         $("#qrcontainer").removeClass("hidden")
                         $("#refresh_qrcode").addClass("hidden")
@@ -137,7 +137,7 @@
             $('#save').click(function () {
                 var confContent = editor.getValue();
                 let timeStamp = (new Date()).getTime()
-                $.post('/api/save?t='+timeStamp, { content: confContent, name: "config.sh" }, function (data) {
+                $.post('./api/save?t='+timeStamp, { content: confContent, name: "config.sh" }, function (data) {
                     let icon = (data.err == 0) ? "success" : "error"
                     Swal.fire({
                         title:data.title,

--- a/panel/public/pwd.html
+++ b/panel/public/pwd.html
@@ -15,11 +15,11 @@
 		<div class="diffs">
 			<nav>
 				<ul>
-					<li><a href="/home">首页</a></li>
-					<li><a href="/crontab">定时设定</a></li>
-					<li><a href="/diff">对比工具</a></li>
-					<li class="active"><a href="/changepwd">修改密码</a></li>
-					<li><a href="/logout">退出</a></li>
+					<li><a href="./home">首页</a></li>
+					<li><a href="./crontab">定时设定</a></li>
+					<li><a href="./diff">对比工具</a></li>
+					<li class="active"><a href="./changepwd">修改密码</a></li>
+					<li><a href="./logout">退出</a></li>
 				</ul>
 			</nav>
 			<div class="login-form">
@@ -37,7 +37,7 @@
 			$user = $(".username").val();
 			$password = $(".password").val();
 			let timeStamp = (new Date()).getTime()
-			$.post('/changepass?t='+timeStamp, { username: $user, password: $password }, function (data) {
+			$.post('./changepass?t='+timeStamp, { username: $user, password: $password }, function (data) {
 				let icon = (data.err == 0) ? "success" : "error"
 				Swal.fire({
 					text: data.msg,

--- a/panel/server.js
+++ b/panel/server.js
@@ -209,7 +209,7 @@ function bakConfFile(file) {
         default:
             break;
     }
-    
+
 }
 
 /**
@@ -258,7 +258,7 @@ app.use(express.static(path.join(__dirname, 'public')));
  */
 app.get('/', function (request, response) {
     if (request.session.loggedin) {
-        response.redirect('/home');
+        response.redirect('./home');
     } else {
         response.sendFile(path.join(__dirname + '/public/auth.html'));
     }
@@ -271,7 +271,7 @@ app.get('/changepwd', function (request, response) {
     if (request.session.loggedin) {
         response.sendFile(path.join(__dirname + '/public/pwd.html'));
     } else {
-        response.redirect('/');
+        response.redirect('./');
     }
 });
 
@@ -360,7 +360,7 @@ app.get('/home', function (request, response) {
     if (request.session.loggedin) {
         response.sendFile(path.join(__dirname + '/public/home.html'));
     } else {
-        response.redirect('/');
+        response.redirect('./');
     }
 
 });
@@ -372,7 +372,7 @@ app.get('/diff', function (request, response) {
     if (request.session.loggedin) {
         response.sendFile(path.join(__dirname + '/public/diff.html'));
     } else {
-        response.redirect('/');
+        response.redirect('./');
     }
 
 });
@@ -384,7 +384,7 @@ app.get('/crontab', function (request, response) {
     if (request.session.loggedin) {
         response.sendFile(path.join(__dirname + '/public/crontab.html'));
     } else {
-        response.redirect('/');
+        response.redirect('./');
     }
 
 });
@@ -445,7 +445,7 @@ app.post('/changepass', function (request, response) {
  */
 app.get('/logout', function (request, response) {
     request.session.destroy()
-    response.redirect('/');
+    response.redirect('./');
 
 });
 


### PR DESCRIPTION
解决Nginx等web服务器反向代理后链接错误的问题。

例如：反向代理后访问的地址为 https://www.example.com/jd/，使用绝对路径时，API的路径会变成https://www.example.com/auth，导致panel无法使用，代理后正确的路径应该是https://www.example.com/jd/auth